### PR TITLE
Add copy to clipboard button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,10 +48,22 @@
         <progress class="progress is-info is-small" v-bind:value="period - updatingIn" :max="period"></progress>
       </div>
 
-      <div class="tile is-ancestor">
+      <div class="tile is-ancestor is-vertical">
         <div class="tile box">
-          <p class="title is-size-1 has-text-centered" style="margin: auto">{{ token }}</p>
+          <textarea
+            class="title is-size-1 has-text-centered"
+            style="margin: auto; border: none; overflow: hidden; outline: none; box-shadow: none; resize: none;"
+            rows="1"
+            readonly
+            ref="tokenInput"
+          >{{ token }}</textarea>
         </div>
+        <div class="tile button is-fullwidth" @click='copyToClipboard'>
+          Copy to clipboard
+        </div>
+        <p class="tag">
+          Or refresh the page to select the token
+        </p>
       </div>
 
     </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -36,6 +36,9 @@ new Vue({
 
   mounted: function () {
     this.update();
+    this.$nextTick(function () {
+      this.copyToClipboard();
+    })
 
     this.intervalHandle = setInterval(this.update, 1000);
   },
@@ -59,6 +62,12 @@ new Vue({
     update: function () {
       this.updatingIn = this.period - (getCurrentSeconds() % this.period);
       this.token = truncateTo(this.totp.generate(), this.digits);
+    },
+    copyToClipboard: function() {
+      if (!this.$refs.tokenInput) return;
+
+      this.$refs.tokenInput.select();
+      document.execCommand('copy');
     }
   }
 });


### PR DESCRIPTION
Added a copy to clipboard button and select the token on page load.

Changed the `<p>` tag to `<textarea>` where the token is rendered for easier content selection and copy. We could create a temporary Textarea inside the copy function to prevent changing the HTML but then the token content would be more difficult to select on page load.

Added `copyToClipboard` function in Vue component to handle coping and called it on component mount to select the text (it doesn't copy since `document.execCommand` can only be invoked on verified user input eg. click).